### PR TITLE
python 3 compability / updated kernelbase source

### DIFF
--- a/stata_kernel/stata_kernel.py
+++ b/stata_kernel/stata_kernel.py
@@ -4,7 +4,7 @@ import time
 import tempfile
 
 import win32com.client
-from IPython.kernel.zmq.kernelbase import Kernel
+from ipykernel.kernelbase import Kernel
 from IPython.core.magic import register_line_cell_magic
 
 
@@ -32,7 +32,7 @@ class StataKernel(Kernel):
         self.log_file = open(self.log_address)
         self.continuation = False
         
-        print 'init complete'
+        print('init complete')
         
     def remove_continuations(self, code):
         return re.sub(r'\s*\\\\\\\s*\n', ' ', code)


### PR DESCRIPTION
This version works for Python 3.4+ and IPython 4